### PR TITLE
Named Exports

### DIFF
--- a/ansicolor.js
+++ b/ansicolor.js
@@ -426,7 +426,9 @@ Colors.rgb = {
 
 /*  ------------------------------------------------------------------------ */
 
-module.exports = Colors
+// Named exports
+const ColorEntries = Object.getOwnPropertyNames(Colors).map(s => [s, Colors[s]])
+module.exports = Object.assign({ default: Colors }, Object.fromEntries(ColorEntries))
 
 /*  ------------------------------------------------------------------------ */
 


### PR DESCRIPTION
https://bignerdranch.com/blog/default-exports-or-named-exports-why-not-both/
https://www.sitepoint.com/understanding-module-exports-exports-node-js/

Breaking change for people who used the Colors class as a class directly. People who cherry picked, implemented a workaround for ES Modules or used the static methods would not be affected.

```
const { parse: xplAnsicolorParse } = require('ansicolor') // Works normally
import { parse as xplAnsicolorParse } from 'ansicolor' // Didn't work, now works
import ASPKG from 'ansicolor' // Didn't work, now works
const { parse: xplAnsicolorParse } = PKG // Still works

const Colors = require('ansicolor')
Colors.parse() // Works
new Colors // Will not work!

const { default: Colors } = require('ansicolor') // Did not work, now works
new Colors // Will work
```