### PR TITLE
fix: types exports for modern TypeScript bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "exports": {
     "import": "./build/ansicolor.mjs",
-    "require": "./build/ansicolor.js"
+    "require": "./build/ansicolor.js",
+    "types": "./ansicolor.d.ts"
   },
   "keywords": [
     "ANSI",


### PR DESCRIPTION
When using modern TypeScript configurations, such as with `moduleResolution: bundler`, the `types` field in the `package.json` is ignored when `exports` is specified.

This PR simply adds `types` to the `exports` definition, so TypeScript types load as expected.